### PR TITLE
Removed test environment override in Paparazzi settings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,7 +74,7 @@ kotlinSerializationPluginVersion = "2.0.0"
 ktlintPluginVersion = "12.1.0"
 metalava = "0.3.5"
 mavenPublish = "0.28.0"
-paparazziPluginVersion = "1.3.4"
+paparazziPluginVersion = "1.3.1"
 
 [libraries]
 androidCoreDependencies-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidAppCompatVersion" }

--- a/snapshottesting/src/main/java/com/urlaunched/android/snapshottesting/BaseSnapshotTest.kt
+++ b/snapshottesting/src/main/java/com/urlaunched/android/snapshottesting/BaseSnapshotTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.detectEnvironment
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
 import com.urlaunched.android.design.ui.paging.LocalPagingMode
@@ -26,7 +27,10 @@ abstract class BaseSnapshotTest(
             deviceConfig = DeviceConfig.PIXEL_5,
             renderingMode = renderingMode,
             showSystemUi = false,
-            maxPercentDifference = 0.1
+            maxPercentDifference = 0.1,
+            environment = detectEnvironment().run {
+                copy(compileSdkVersion = 33, platformDir = platformDir.replace("34", "33"))
+            }
         )
 
     fun snapshot(pagingMode: LocalPagingModeEnum? = null, composable: @Composable () -> Unit) {

--- a/snapshottesting/src/main/java/com/urlaunched/android/snapshottesting/BaseSnapshotTest.kt
+++ b/snapshottesting/src/main/java/com/urlaunched/android/snapshottesting/BaseSnapshotTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
-import app.cash.paparazzi.detectEnvironment
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
 import com.urlaunched.android.design.ui.paging.LocalPagingMode
@@ -27,10 +26,7 @@ abstract class BaseSnapshotTest(
             deviceConfig = DeviceConfig.PIXEL_5,
             renderingMode = renderingMode,
             showSystemUi = false,
-            maxPercentDifference = 0.1,
-            environment = detectEnvironment().run {
-                copy(compileSdkVersion = 33, platformDir = platformDir.replace("34", "33"))
-            }
+            maxPercentDifference = 0.1
         )
 
     fun snapshot(pagingMode: LocalPagingModeEnum? = null, composable: @Composable () -> Unit) {


### PR DESCRIPTION
Removed test environment override in Paparazzi settings due to this issue to fix tests https://github.com/cashapp/paparazzi/issues/1444