### PR TITLE
Add modifier access rules

### DIFF
--- a/ktlintrules/src/main/java/com/urlaunched/android/ktlintrules/ComposableAccessModifiersRule.kt
+++ b/ktlintrules/src/main/java/com/urlaunched/android/ktlintrules/ComposableAccessModifiersRule.kt
@@ -1,0 +1,66 @@
+package com.urlaunched.android.ktlintrules
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import utils.CustomRulesUtils.isComposable
+import utils.CustomRulesUtils.isPreview
+import utils.CustomRulesUtils.isPrivate
+import utils.CustomRulesUtils.isPublic
+
+class ComposableAccessModifiersRule :
+    Rule(
+        RuleId(CUSTOM_RULE_ID),
+        about = About()
+    ),
+    RuleAutocorrectApproveHandler {
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision
+    ) {
+        if (node.elementType == ElementType.FUN) {
+            val function = node.psi as? KtNamedFunction ?: return
+            if (!function.isComposable) return
+
+            val containingFile = function.containingKtFile
+            val packageDirective = containingFile.packageDirective
+            val packageName = packageDirective?.fqName?.asString()
+            val isInFeatureModule = packageName?.contains(FEATURE_PACKAGE_NAME) ?: false
+
+            when {
+                function.isPreview -> {
+                    if (!function.isPrivate) {
+                        emit(
+                            node.startOffset,
+                            PREVIEW_ERROR_MESSAGE,
+                            false
+                        )
+                    }
+                }
+
+                isInFeatureModule -> {
+                    if (function.isPublic && function.name?.contains(SCREEN_POSTFIX) == false) {
+                        emit(
+                            node.startOffset,
+                            COMPOSABLE_ACCESS_MODIFIER_ERROR_MESSAGE,
+                            false
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val CUSTOM_RULE_ID = "ktlintrules:composable-access-modifier-rule"
+        private const val PREVIEW_ERROR_MESSAGE = "Previews should be private"
+        private const val COMPOSABLE_ACCESS_MODIFIER_ERROR_MESSAGE =
+            "Composable fun in feature module should be internal or private"
+        private const val FEATURE_PACKAGE_NAME = "features"
+        private const val SCREEN_POSTFIX = "Screen"
+    }
+}

--- a/ktlintrules/src/main/java/com/urlaunched/android/ktlintrules/DataAccessModifierRule.kt
+++ b/ktlintrules/src/main/java/com/urlaunched/android/ktlintrules/DataAccessModifierRule.kt
@@ -1,0 +1,47 @@
+package com.urlaunched.android.ktlintrules
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFile
+import utils.CustomRulesUtils.isInternal
+
+class DataAccessModifierRule :
+    Rule(
+        RuleId(CUSTOM_RULE_ID),
+        about = About()
+    ),
+    RuleAutocorrectApproveHandler {
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision
+    ) {
+        if (node.elementType == ElementType.CLASS || node.elementType == ElementType.INTERFACE_KEYWORD) {
+            val isInDataPackage = (node.psi.containingFile as? KtFile)
+                ?.packageFqName
+                ?.asString()
+                ?.contains(DATA_PACKAGE_NAME) == true
+
+            if (!isInDataPackage) return
+            val clazz = node.psi as? KtClass ?: return
+
+            if (!clazz.isInternal) {
+                emit(
+                    node.startOffset,
+                    DATA_ACCESS_ERROR,
+                    false
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val CUSTOM_RULE_ID = "ktlintrules:data-access-modifier-rule"
+        private const val DATA_PACKAGE_NAME = "data"
+        private const val DATA_ACCESS_ERROR = "Classes and Interfaces in 'data' package must be internal."
+    }
+}

--- a/ktlintrules/src/main/java/com/urlaunched/android/ktlintrules/DataAccessModifierRule.kt
+++ b/ktlintrules/src/main/java/com/urlaunched/android/ktlintrules/DataAccessModifierRule.kt
@@ -8,6 +8,7 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.psiUtil.isPublic
 import utils.CustomRulesUtils.isInternal
 
 class DataAccessModifierRule :
@@ -29,7 +30,7 @@ class DataAccessModifierRule :
             if (!isInDataPackage) return
             val clazz = node.psi as? KtClass ?: return
 
-            if (!clazz.isInternal) {
+            if (clazz.isPublic) {
                 emit(
                     node.startOffset,
                     DATA_ACCESS_ERROR,
@@ -42,6 +43,6 @@ class DataAccessModifierRule :
     companion object {
         private const val CUSTOM_RULE_ID = "ktlintrules:data-access-modifier-rule"
         private const val DATA_PACKAGE_NAME = "data"
-        private const val DATA_ACCESS_ERROR = "Classes and Interfaces in 'data' package must be internal."
+        private const val DATA_ACCESS_ERROR = "Classes and Interfaces in 'data' package should not be public."
     }
 }

--- a/ktlintrules/src/main/java/com/urlaunched/android/ktlintrules/RuleSetProvider.kt
+++ b/ktlintrules/src/main/java/com/urlaunched/android/ktlintrules/RuleSetProvider.kt
@@ -8,6 +8,8 @@ internal const val CUSTOM_RULE_SET_ID = "url-rule-set-id"
 
 class RuleSetProvider : RuleSetProviderV3(RuleSetId(CUSTOM_RULE_SET_ID)) {
     override fun getRuleProviders(): Set<RuleProvider> = setOf(
-        RuleProvider { ForbiddenImportsRule() }
+        RuleProvider { ForbiddenImportsRule() },
+        RuleProvider { ComposableAccessModifiersRule() },
+        RuleProvider { DataAccessModifierRule() }
     )
 }

--- a/ktlintrules/src/main/java/utils/CustomRulesUtils.kt
+++ b/ktlintrules/src/main/java/utils/CustomRulesUtils.kt
@@ -1,0 +1,40 @@
+package utils
+
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPsiUtil
+import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
+
+object CustomRulesUtils {
+    private val KtAnnotationEntry.isPreviewAnnotation: Boolean
+        get() = calleeExpression?.text?.contains("Preview") == true
+
+    val KtNamedFunction.isPreview: Boolean
+        get() = annotationEntries.any { it.isPreviewAnnotation }
+
+    val KtNamedFunction.isPublic: Boolean
+        get() {
+            if (KtPsiUtil.isLocal(this)) return false
+            val visibilityModifier = visibilityModifierType()
+            return visibilityModifier == null || visibilityModifier == KtTokens.PUBLIC_KEYWORD
+        }
+
+    val KtNamedFunction.isPrivate: Boolean
+        get() {
+            if (KtPsiUtil.isLocal(this)) return false
+            val visibilityModifier = visibilityModifierType()
+            return visibilityModifier == null || visibilityModifier == KtTokens.PRIVATE_KEYWORD
+        }
+
+    val KtClass.isInternal: Boolean
+        get() {
+            if (KtPsiUtil.isLocal(this)) return false
+            val visibilityModifier = visibilityModifierType()
+            return visibilityModifier == KtTokens.INTERNAL_KEYWORD
+        }
+
+    val KtNamedFunction.isComposable: Boolean
+        get() = annotationEntries.any { it.calleeExpression?.text == "Composable" }
+}


### PR DESCRIPTION
Add access modifier rules.
Add rule for composable funs . Previews should be private. Other Composables in features should be internal exept Screens
Add rule for data classes and interfaces. Classes and interfaces should be internal