### PR TITLE
Make performUseCase and loading  tasks generally available

### DIFF
--- a/common/api/current.api
+++ b/common/api/current.api
@@ -431,8 +431,8 @@ package com.urlaunched.android.common.string {
 package com.urlaunched.android.common.viewmodel {
 
   public final class ViewModelExtensionsKt {
-    method public static inline void loadingTask(androidx.lifecycle.ViewModel, kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> setLoading, kotlin.jvm.functions.Function0<kotlin.Unit> block);
-    method public static suspend <T> Object? performUseCase(androidx.lifecycle.ViewModel, kotlin.jvm.functions.Function1<? super kotlin.coroutines.Continuation<? super com.urlaunched.android.common.response.Response<T>>,?> useCase, kotlin.jvm.functions.Function2<? super T,? super kotlin.coroutines.Continuation<? super kotlin.Unit>,?> success, kotlin.jvm.functions.Function2<? super com.urlaunched.android.common.response.ErrorData,? super kotlin.coroutines.Continuation<? super kotlin.Unit>,?> error, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+    method public static inline void loadingTask(kotlin.jvm.functions.Function1<? super java.lang.Boolean,kotlin.Unit> setLoading, kotlin.jvm.functions.Function0<kotlin.Unit> block);
+    method public static suspend <T> Object? performUseCase(kotlin.jvm.functions.Function1<? super kotlin.coroutines.Continuation<? super com.urlaunched.android.common.response.Response<T>>,?> useCase, kotlin.jvm.functions.Function2<? super T,? super kotlin.coroutines.Continuation<? super kotlin.Unit>,?> success, kotlin.jvm.functions.Function2<? super com.urlaunched.android.common.response.ErrorData,? super kotlin.coroutines.Continuation<? super kotlin.Unit>,?> error, kotlin.coroutines.Continuation<? super kotlin.Unit>);
   }
 
 }

--- a/common/src/main/java/com/urlaunched/android/common/viewmodel/ViewModelExtensions.kt
+++ b/common/src/main/java/com/urlaunched/android/common/viewmodel/ViewModelExtensions.kt
@@ -1,10 +1,9 @@
 package com.urlaunched.android.common.viewmodel
 
-import androidx.lifecycle.ViewModel
 import com.urlaunched.android.common.response.ErrorData
 import com.urlaunched.android.common.response.Response
 
-suspend fun <T : Any> ViewModel.performUseCase(
+suspend fun <T : Any> performUseCase(
     useCase: suspend () -> Response<T>,
     success: suspend (data: T) -> Unit,
     error: suspend (error: ErrorData) -> Unit
@@ -20,7 +19,7 @@ suspend fun <T : Any> ViewModel.performUseCase(
     }
 }
 
-inline fun ViewModel.loadingTask(setLoading: (isLoading: Boolean) -> Unit, block: () -> Unit) {
+inline fun loadingTask(setLoading: (isLoading: Boolean) -> Unit, block: () -> Unit) {
     try {
         setLoading(true)
         block()


### PR DESCRIPTION
Make performUseCase and loading  tasks generally available for usages outside of ViewModels (e.g. delegates, micro-features)