### PR TITLE
Fix bottom sheet initial state during snapshot tests

### DIFF
--- a/design/src/main/java/com/urlaunched/android/design/ui/bottomsheet/BaseBottomSheet.kt
+++ b/design/src/main/java/com/urlaunched/android/design/ui/bottomsheet/BaseBottomSheet.kt
@@ -46,7 +46,7 @@ fun BaseBottomSheet(
     val density = LocalDensity.current
 
     val sheetState = rememberModalBottomSheetState(
-        initialDetent = if (LocalInspectionMode.current) SheetDetent.FullyExpanded else SheetDetent.Hidden,
+        initialDetent = if (LocalInspectionMode.current && isShow) SheetDetent.FullyExpanded else SheetDetent.Hidden,
         detents = if (skipPartiallyExpanded) {
             listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded)
         } else {


### PR DESCRIPTION
Fix bottom sheet initial state during snapshot tests which caused dim to be drawn over the snapshot image even if bottomsheet is hidden