### PR TITLE
Fix/parallel images compression

### DIFF
--- a/common/src/main/java/com/urlaunched/android/common/compression/CompressImageUtil.kt
+++ b/common/src/main/java/com/urlaunched/android/common/compression/CompressImageUtil.kt
@@ -63,40 +63,42 @@ object CompressImageUtil {
         var targetHeight = rotatedBitmap.height
 
         var resizedBitmap = rotatedBitmap.scale(targetWidth, targetHeight)
-        val byteArrayOutputStream = ByteArrayOutputStream()
-        var fileSize: Long
 
-        do {
-            byteArrayOutputStream.reset()
-            resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayOutputStream)
+        return ByteArrayOutputStream().use { byteArrayOutputStream ->
+            var fileSize: Long
 
-            val byteArray = byteArrayOutputStream.toByteArray()
-            fileSize = byteArray.size.toLong()
+            do {
+                byteArrayOutputStream.reset()
+                resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayOutputStream)
+
+                val byteArray = byteArrayOutputStream.toByteArray()
+                fileSize = byteArray.size.toLong()
+
+                if (fileSize > targetSize) {
+                    targetWidth = (targetWidth * 0.9).toInt()
+                    targetHeight = (targetHeight * 0.9).toInt()
+
+                    if (targetWidth * targetHeight < minWidth * minHeight) {
+                        break
+                    }
+
+                    resizedBitmap = rotatedBitmap.scale(targetWidth, targetHeight)
+                }
+            } while (fileSize > targetSize)
 
             if (fileSize > targetSize) {
-                targetWidth = (targetWidth * 0.9).toInt()
-                targetHeight = (targetHeight * 0.9).toInt()
-
-                if (targetWidth * targetHeight < minWidth * minHeight) {
-                    break
-                }
-
-                resizedBitmap = rotatedBitmap.scale(targetWidth, targetHeight)
+                resizedBitmap.recycle()
+                return null
             }
-        } while (fileSize > targetSize)
 
-        if (fileSize > targetSize) {
+            FileOutputStream(compressedFile).use { fos ->
+                fos.write(byteArrayOutputStream.toByteArray())
+            }
+
             resizedBitmap.recycle()
-            return null
+
+            compressedFile
         }
-
-        FileOutputStream(compressedFile).use { fos ->
-            fos.write(byteArrayOutputStream.toByteArray())
-        }
-
-        resizedBitmap.recycle()
-
-        return compressedFile
     }
 
     private fun rotateBitmapIfNeeded(bitmap: Bitmap, orientation: Int): Bitmap {

--- a/common/src/main/java/com/urlaunched/android/common/compression/CompressImageUtil.kt
+++ b/common/src/main/java/com/urlaunched/android/common/compression/CompressImageUtil.kt
@@ -12,7 +12,7 @@ import okio.use
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
-import java.time.Instant
+import java.util.UUID
 
 object CompressImageUtil {
     private const val DEFAULT_TARGET_SIZE_BYTES: Long = 5 * 1000 * 1000
@@ -47,7 +47,7 @@ object CompressImageUtil {
             outDir.mkdirs()
         }
 
-        val compressedFile = File(outDir, "compressed_${Instant.now().toEpochMilli()}.jpg")
+        val compressedFile = File(outDir, "compressed_${UUID.randomUUID()}.jpg")
         val originalBitmap = context.contentResolver.openInputStream(input).use { inputStream ->
             BitmapFactory.decodeStream(inputStream)
         }


### PR DESCRIPTION
- If compression of images done in parallel it is possible that the temp file names will collide which will result in one image compression result overriding another. Fix this by using uuid as a temp file name
- Additionally, fix ByteArrayOutputStream resources leak, which was never closed after compression finished