### PR TITLE
fix basic text field

### DIFF
--- a/design/src/main/java/com/urlaunched/android/design/ui/textfield/TextField.kt
+++ b/design/src/main/java/com/urlaunched/android/design/ui/textfield/TextField.kt
@@ -242,8 +242,14 @@ fun TextField(
                                     bottom = innerPadding.calculateBottomPadding()
                                 )
                                 .weight(1f)
-                                .wrapContentHeight()
+                                .wrapContentHeight(),
+                            contentAlignment = Alignment.CenterStart
                         ) {
+                            // Need to prevent text field height from bouncing,
+                            // it should occupy the required height before the first symbol is entered.
+                            // https://issuetracker.google.com/issues/236615813
+                            Text("", style = inputTextConfig.textStyle)
+
                             innerTextField()
 
                             if (value.isEmpty()) {


### PR DESCRIPTION
Проблема в тому, що до того, як буде введено перший символ - BasicTextField не може прорахувати коректно висоту тексту (це може помітити навіть по розміру курсору). 
[https://issuetracker.google.com/issues/236615813](https://issuetracker.google.com/issues/236615813)
Проблема судячи з трекеру мала би бути виправлена, але фактично, проблема залишається актуальною.
Самий швидкий і надійний спосіб, який не зламає реалізацію на існуючих проектах - це додати пустий текст позаду текстфілда з таким самим стилем.