### PR TITLE
Update textfield placeholder placement

### DIFF
--- a/design/src/main/java/com/urlaunched/android/design/ui/textfield/TextField.kt
+++ b/design/src/main/java/com/urlaunched/android/design/ui/textfield/TextField.kt
@@ -240,7 +240,8 @@ fun TextField(
                                     top = innerPadding.calculateTopPadding(),
                                     bottom = innerPadding.calculateBottomPadding()
                                 )
-                                .weight(1f)
+                                .weight(1f),
+                            contentAlignment = Alignment.CenterStart
                         ) {
                             // Need to prevent text field height from bouncing,
                             // it should occupy the required height before the first symbol is entered.
@@ -254,6 +255,7 @@ fun TextField(
                                     text = placeHolder ?: label.orEmpty(),
                                     style = inputPlaceholderTextConfig.textStyle,
                                     color = inputPlaceholderTextConfig.color,
+                                    minLines = minLines,
                                     maxLines = maxLines,
                                     overflow = TextOverflow.Ellipsis
                                 )


### PR DESCRIPTION
- Set placeholder's min lines the same as the textfield min lines
- Add textfield content box center alignment

This guarantees that textfield's placeholder is always centered, while retaining its expected position in multiline textfield