### PR TITLE
Implement snapshot test locale variants

### DIFF
--- a/snapshottesting/api/current.api
+++ b/snapshottesting/api/current.api
@@ -2,7 +2,7 @@
 package com.urlaunched.android.snapshottesting {
 
   public abstract class BaseSnapshotTest {
-    ctor public BaseSnapshotTest(optional app.cash.paparazzi.DeviceConfig deviceConfig, optional com.android.ide.common.rendering.api.SessionParams.RenderingMode renderingMode, optional boolean supportsDarkMode, optional boolean supportsLandscape, optional boolean supportsRtl);
+    ctor public BaseSnapshotTest(optional app.cash.paparazzi.DeviceConfig deviceConfig, optional com.android.ide.common.rendering.api.SessionParams.RenderingMode renderingMode, optional boolean supportsDarkMode, optional boolean supportsLandscape, optional boolean supportsRtl, optional java.util.List<java.lang.String> languages);
     method @org.junit.Rule public final com.urlaunched.android.snapshottesting.DefaultLocaleRule getLocalRule();
     method @org.junit.Rule public app.cash.paparazzi.Paparazzi getPaparazzi();
     method public final void snapshot(kotlin.jvm.functions.Function0<kotlin.Unit> composable);

--- a/snapshottesting/src/main/java/com/urlaunched/android/snapshottesting/BaseSnapshotTest.kt
+++ b/snapshottesting/src/main/java/com/urlaunched/android/snapshottesting/BaseSnapshotTest.kt
@@ -4,21 +4,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.unit.LayoutDirection
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import app.cash.paparazzi.detectEnvironment
 import com.android.ide.common.rendering.api.SessionParams
+import com.android.resources.LayoutDirection
 import com.android.resources.NightMode
 import com.android.resources.ScreenOrientation
 import org.junit.Rule
+import java.util.Locale
+import androidx.compose.ui.unit.LayoutDirection as ComposeLayoutDirection
 
 abstract class BaseSnapshotTest(
     private val deviceConfig: DeviceConfig = DeviceConfig.PIXEL_5,
     renderingMode: SessionParams.RenderingMode = SessionParams.RenderingMode.NORMAL,
     private val supportsDarkMode: Boolean = false,
     private val supportsLandscape: Boolean = false,
-    private val supportsRtl: Boolean = false
+    private val supportsRtl: Boolean = false,
+    private val languages: List<String> = emptyList()
 ) {
     @get:Rule
     val localRule = DefaultLocaleRule()
@@ -36,129 +39,130 @@ abstract class BaseSnapshotTest(
         )
 
     fun snapshot(composable: @Composable () -> Unit) {
-        when {
-            supportsDarkMode && supportsLandscape && supportsRtl -> {
-                lightPortraitConfig()
-                paparazziSnapshot("light", false, composable)
+        val languages: List<String?> = languages.ifEmpty { listOf(null) }
+        val themes = if (supportsDarkMode) listOf(NightMode.NOTNIGHT, NightMode.NIGHT) else listOf(NightMode.NOTNIGHT)
 
-                lightLandscapeConfig()
-                paparazziSnapshot("light_landscape", false, composable)
+        languages.forEach { lang ->
+            val isLangRtl = isRtlLanguage(lang)
+            for (theme in themes) {
+                updateConfig(theme = theme, landscape = false, languageTagOrIso = lang)
+                paparazziSnapshot(
+                    name = snapshotName(theme = theme, landscape = false, rtl = false, lang = lang),
+                    isRtl = isLangRtl,
+                    composable = composable
+                )
 
-                lightPortraitConfig()
-                paparazziSnapshot("light_rtl", true, composable)
+                if (supportsLandscape) {
+                    updateConfig(theme = theme, landscape = true, languageTagOrIso = lang)
+                    paparazziSnapshot(
+                        name = snapshotName(theme = theme, landscape = true, rtl = false, lang = lang),
+                        isRtl = isLangRtl,
+                        composable = composable
+                    )
+                }
 
-                darkPortraitConfig()
-                paparazziSnapshot("dark", false, composable)
+                if (!isLangRtl &&
+                    supportsRtl &&
+                    languages.none { isRtlLanguage(it) } &&
+                    lang == languages.first()
+                ) {
+                    updateConfig(theme = theme, landscape = false, languageTagOrIso = lang, forceRtl = true)
+                    paparazziSnapshot(
+                        name = snapshotName(theme = theme, landscape = false, rtl = true, lang = lang),
+                        isRtl = true,
+                        composable = composable
+                    )
 
-                darkLandscapeConfig()
-                paparazziSnapshot("dark_landscape", false, composable)
-
-                darkPortraitConfig()
-                paparazziSnapshot("dark_rtl", true, composable)
-            }
-
-            supportsDarkMode && supportsLandscape && !supportsRtl -> {
-                lightPortraitConfig()
-                paparazziSnapshot("light", false, composable)
-
-                lightLandscapeConfig()
-                paparazziSnapshot("light_landscape", false, composable)
-
-                darkPortraitConfig()
-                paparazziSnapshot("dark", false, composable)
-
-                darkLandscapeConfig()
-                paparazziSnapshot("dark_landscape", false, composable)
-            }
-
-            supportsDarkMode && !supportsLandscape && supportsRtl -> {
-                lightPortraitConfig()
-                paparazziSnapshot("light", false, composable)
-
-                paparazziSnapshot("light_rtl", true, composable)
-
-                darkPortraitConfig()
-                paparazziSnapshot("dark", false, composable)
-
-                paparazziSnapshot("dark_rtl", true, composable)
-            }
-
-            supportsDarkMode && !supportsLandscape && !supportsRtl -> {
-                lightPortraitConfig()
-                paparazziSnapshot("light", false, composable)
-
-                darkPortraitConfig()
-                paparazziSnapshot("dark", false, composable)
-            }
-
-            !supportsDarkMode && supportsLandscape && !supportsRtl -> {
-                lightPortraitConfig()
-                paparazziSnapshot("light", false, composable)
-
-                lightLandscapeConfig()
-                paparazziSnapshot("light_landscape", false, composable)
-            }
-
-            !supportsDarkMode && !supportsLandscape && supportsRtl -> {
-                lightPortraitConfig()
-                paparazziSnapshot("light", false, composable)
-
-                paparazziSnapshot("light_rtl", true, composable)
-            }
-
-            else -> {
-                lightPortraitConfig()
-                paparazziSnapshot("light", false, composable)
+                    if (supportsLandscape) {
+                        updateConfig(theme = theme, landscape = true, languageTagOrIso = lang, forceRtl = true)
+                        paparazziSnapshot(
+                            name = snapshotName(theme = theme, landscape = true, rtl = true, lang = lang),
+                            isRtl = true,
+                            composable = composable
+                        )
+                    }
+                }
             }
         }
+    }
+
+    private fun snapshotName(theme: NightMode, landscape: Boolean, rtl: Boolean, lang: String?): String {
+        val base = buildList {
+            add(if (theme == NightMode.NIGHT) "dark" else "light")
+
+            if (landscape) {
+                add("landscape")
+            }
+
+            if (rtl) {
+                add("rtl")
+            }
+        }.joinToString("_")
+        return if (lang.isNullOrBlank()) base else "${base}_$lang"
+    }
+
+    private fun isRtlLanguage(languageTagOrIso: String?): Boolean {
+        if (languageTagOrIso.isNullOrBlank()) return false
+        val primary = languageTagOrIso
+            .replace('_', '-')
+            .lowercase(Locale.ROOT)
+            .substringBefore('-')
+        val rtl = setOf(
+            "ar", "fa", "he", "iw",
+            "ur", "ps", "sd", "ug", "yi", "dv", "ku", "ckb", "nqo"
+        )
+        return primary in rtl
+    }
+
+    private fun String.toLocale(): Locale = if (contains('-') || contains('_')) {
+        Locale.forLanguageTag(replace('_', '-'))
+    } else {
+        Locale(this)
+    }
+
+    private fun updateConfig(
+        theme: NightMode,
+        landscape: Boolean,
+        languageTagOrIso: String?,
+        forceRtl: Boolean = false
+    ) {
+        val base = if (landscape) {
+            deviceConfig.copy(
+                orientation = ScreenOrientation.LANDSCAPE,
+                screenHeight = deviceConfig.screenWidth,
+                screenWidth = deviceConfig.screenHeight,
+                nightMode = theme
+            )
+        } else {
+            deviceConfig.copy(
+                orientation = ScreenOrientation.PORTRAIT,
+                screenHeight = deviceConfig.screenHeight,
+                screenWidth = deviceConfig.screenWidth,
+                nightMode = theme
+            )
+        }
+        val cfg = if (!languageTagOrIso.isNullOrBlank()) {
+            val desired = languageTagOrIso.toLocale()
+            base.copy(
+                locale = desired.toLanguageTag(),
+                layoutDirection = if (isRtlLanguage(languageTagOrIso) || forceRtl) LayoutDirection.RTL else LayoutDirection.LTR
+            )
+        } else {
+            base.copy(
+                layoutDirection = if (forceRtl) LayoutDirection.RTL else LayoutDirection.LTR
+            )
+        }
+        paparazzi.unsafeUpdateConfig(deviceConfig = cfg)
     }
 
     private fun paparazziSnapshot(name: String, isRtl: Boolean, composable: @Composable () -> Unit) {
         paparazzi.snapshot(name) {
             CompositionLocalProvider(
                 LocalInspectionMode provides true,
-                LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr
+                LocalLayoutDirection provides if (isRtl) ComposeLayoutDirection.Rtl else ComposeLayoutDirection.Ltr
             ) {
                 composable()
             }
         }
-    }
-
-    private val lightPortraitConfig = {
-        paparazzi.unsafeUpdateConfig(
-            deviceConfig = deviceConfig.copy(
-                nightMode = NightMode.NOTNIGHT
-            )
-        )
-    }
-
-    private val lightLandscapeConfig = {
-        paparazzi.unsafeUpdateConfig(
-            deviceConfig = deviceConfig.copy(
-                orientation = ScreenOrientation.LANDSCAPE,
-                screenHeight = deviceConfig.screenWidth,
-                screenWidth = deviceConfig.screenHeight,
-                nightMode = NightMode.NOTNIGHT
-            )
-        )
-    }
-
-    private val darkPortraitConfig = {
-        paparazzi.unsafeUpdateConfig(
-            deviceConfig = deviceConfig.copy(
-                nightMode = NightMode.NIGHT
-            )
-        )
-    }
-
-    private val darkLandscapeConfig = {
-        paparazzi.unsafeUpdateConfig(
-            deviceConfig = deviceConfig.copy(
-                orientation = ScreenOrientation.LANDSCAPE,
-                screenHeight = deviceConfig.screenWidth,
-                screenWidth = deviceConfig.screenHeight,
-                nightMode = NightMode.NIGHT
-            )
-        )
     }
 }


### PR DESCRIPTION
Implement snapshot images generation for each of the supplied languages
- If no languages list is supplied the behavior stays the same
- If languages list is supplied:
    -  every image will have suffix of the language. 
    - If rtl support is enabled through the constructor param and no rtl language is included in the languages list then rtl snapshots will be generated only for the first listed language
    - If rtl support is enabled through the constructor param and rtl language is included in the languages list no additional rtl snapshots will be generated