### PR TITLE
Allow to change timeout of OkHttpClient

### DIFF
--- a/network/api/current.api
+++ b/network/api/current.api
@@ -35,7 +35,7 @@ package com.urlaunched.android.network.interceptors {
 package com.urlaunched.android.network.okhttp {
 
   public final class OkHttpInitializer {
-    method public okhttp3.OkHttpClient createGeneralOkHttpClient(boolean enableLogging, optional okhttp3.OkHttpClient? okHttpClient, okhttp3.Interceptor... interceptors);
+    method public okhttp3.OkHttpClient createGeneralOkHttpClient(boolean enableLogging, optional okhttp3.OkHttpClient? okHttpClient, optional long timeoutSeconds, okhttp3.Interceptor... interceptors);
     field public static final com.urlaunched.android.network.okhttp.OkHttpInitializer INSTANCE;
   }
 

--- a/network/src/main/java/com/urlaunched/android/network/okhttp/OkHttpInitializer.kt
+++ b/network/src/main/java/com/urlaunched/android/network/okhttp/OkHttpInitializer.kt
@@ -6,17 +6,18 @@ import okhttp3.logging.HttpLoggingInterceptor
 import java.util.concurrent.TimeUnit
 
 object OkHttpInitializer {
-    private const val DEFAULT_TIMEOUT = 60
+    private const val DEFAULT_TIMEOUT_SECONDS = 60L
 
     fun createGeneralOkHttpClient(
         enableLogging: Boolean,
         okHttpClient: OkHttpClient? = null,
+        timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
         vararg interceptors: Interceptor
     ): OkHttpClient {
         val builder = (okHttpClient?.newBuilder() ?: OkHttpClient.Builder())
-            .callTimeout(DEFAULT_TIMEOUT.toLong(), TimeUnit.SECONDS)
-            .readTimeout(DEFAULT_TIMEOUT.toLong(), TimeUnit.SECONDS)
-            .writeTimeout(DEFAULT_TIMEOUT.toLong(), TimeUnit.SECONDS)
+            .callTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .writeTimeout(timeoutSeconds, TimeUnit.SECONDS)
             .retryOnConnectionFailure(true)
             .apply {
                 interceptors.forEach {


### PR DESCRIPTION
Changed the `createGeneralOkHttpClient` function of `OkHttpInitializer` to receive optional parameter `timeoutSeconds` that will allow changing the timeout