### PR TITLE
Migrate away from crashlytics-ktx

### DIFF
--- a/common/src/main/java/com/urlaunched/android/common/navigation/LogScreenEvents.kt
+++ b/common/src/main/java/com/urlaunched/android/common/navigation/LogScreenEvents.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import com.google.firebase.crashlytics.ktx.crashlytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
 import com.google.firebase.perf.FirebasePerformance
 import com.google.firebase.perf.application.FrameMetricsRecorder
 import com.urlaunched.android.common.lifecycle.HandleLifecycleEvents

--- a/common/src/main/java/com/urlaunched/android/common/pagination/RemotePagingSource.kt
+++ b/common/src/main/java/com/urlaunched/android/common/pagination/RemotePagingSource.kt
@@ -2,8 +2,8 @@ package com.urlaunched.android.common.pagination
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import com.google.firebase.crashlytics.ktx.crashlytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
 import com.urlaunched.android.common.response.ErrorData
 import com.urlaunched.android.common.response.Response
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ retrofitVersion = "2.11.0"
 okHttpVersion = "4.12.0"
 
 # firebaseDependencies
-firebaseBomVersion = "33.4.0"
+firebaseBomVersion = "34.7.0"
 
 # billingDependencies
 billingVersion = "7.1.1"
@@ -179,7 +179,7 @@ networkDependencies-okHttpLogging = { module = "com.squareup.okhttp3:logging-int
 networkDependencies-kotlinSerialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofitVersion" }
 
 firebaseDependencies-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBomVersion" }
-firebaseDependencies-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
+firebaseDependencies-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebaseDependencies-remoteconfig = { module = "com.google.firebase:firebase-config" }
 firebaseDependencies-performance = { module = "com.google.firebase:firebase-perf" }
 

--- a/logger/aspect/src/main/java/com/urlaunched/android/logger/aspect/KotlinAspect.kt
+++ b/logger/aspect/src/main/java/com/urlaunched/android/logger/aspect/KotlinAspect.kt
@@ -1,8 +1,8 @@
 package com.urlaunched.android.logger.aspect
 
 import androidx.paging.PagingData
-import com.google.firebase.crashlytics.ktx.crashlytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
 import com.urlaunched.android.common.pagination.PagingFlowWithMeta
 import com.urlaunched.android.common.response.Response
 import kotlinx.coroutines.CoroutineScope

--- a/remoteconfig/src/main/java/com/urlaunched/android/remoteconfig/basehandler/BaseRemoteConfigHandler.kt
+++ b/remoteconfig/src/main/java/com/urlaunched/android/remoteconfig/basehandler/BaseRemoteConfigHandler.kt
@@ -1,9 +1,9 @@
 package com.urlaunched.android.remoteconfig.basehandler
 
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.Firebase
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
-import com.google.firebase.remoteconfig.ktx.remoteConfig
-import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
+import com.google.firebase.remoteconfig.remoteConfig
+import com.google.firebase.remoteconfig.remoteConfigSettings
 import com.urlaunched.android.remoteconfig.data.RemoteConfig
 import kotlinx.coroutines.tasks.await
 import kotlinx.serialization.json.Json


### PR DESCRIPTION
Google no longer publishes crashlytics-ktx artifact. While the library uses older version with the artifact still available, it becomes a problem when consumer project uses an up-to-date version of firebase bom.
Migrate away from crashlytics-ktx and upgrade firebase bom